### PR TITLE
Sync with InsForge-sdk-js v1.5.0

### DIFF
--- a/src/main/kotlin/dev/insforge/storage/BucketApi.kt
+++ b/src/main/kotlin/dev/insforge/storage/BucketApi.kt
@@ -62,6 +62,9 @@ interface BucketApi {
      * - For local storage: Direct upload to the server
      * - For S3: Gets presigned URL, uploads to S3, then confirms
      *
+     * Standard PUT semantics: uploading to an existing key replaces the
+     * current object in place.
+     *
      * @param path The path/key where the file will be stored
      * @param data The file data as ByteArray
      * @param options Additional upload options (content type, upsert, metadata)
@@ -76,9 +79,13 @@ interface BucketApi {
     ): FileUploadResponse
 
     /**
-     * Upload a file to the bucket with auto-generated key.
+     * Upload a file to the bucket under an automatically generated,
+     * collision-free key.
      *
-     * The server will generate a unique key based on the filename.
+     * The key is derived client-side from the filename (sanitized base +
+     * timestamp + random suffix) and uploaded through the standard [upload]
+     * path, so repeated uploads of the same file never overwrite each other.
+     * The storage API has no server-side key minting.
      *
      * @param filename Original filename (used for key generation and content type detection)
      * @param data The file data as ByteArray
@@ -108,7 +115,8 @@ interface BucketApi {
     ): FileUploadResponse
 
     /**
-     * Upload a file from java.io.File with auto-generated key.
+     * Upload a file from java.io.File under an automatically generated,
+     * collision-free key (see [uploadWithAutoKey]).
      *
      * @param file The File to upload (filename used for key generation)
      * @param options Additional upload options
@@ -326,25 +334,15 @@ internal class BucketApiImpl(
         data: ByteArray,
         options: UploadOptions.() -> Unit
     ): FileUploadResponse {
-        require(data.isNotEmpty()) { "The data to upload should not be empty" }
-
         val uploadOptions = UploadOptions().apply(options)
-        val contentType = uploadOptions.contentType
-            ?: detectContentType(filename)
-            ?: "application/octet-stream"
 
-        // Get upload strategy with filename for auto-key generation
-        val strategy = getUploadStrategy(filename, contentType, data.size.toLong())
-
-        return when (strategy.method) {
-            UploadMethod.DIRECT -> {
-                // Direct upload with auto-generated key
-                uploadDirectAutoKey(filename, data, contentType, uploadOptions)
-            }
-            UploadMethod.PRESIGNED -> {
-                // Upload to S3 using presigned URL, then confirm
-                uploadPresigned(strategy, data, contentType, uploadOptions)
-            }
+        // Auto-key generation is a client-side convenience — the storage API
+        // has no server-side key minting — so mint a unique, collision-free
+        // key here and upload through the standard upload() path.
+        return upload(generateObjectKey(filename), data) {
+            contentType = uploadOptions.contentType ?: detectContentType(filename)
+            upsert = uploadOptions.upsert
+            metadata = uploadOptions.metadata
         }
     }
 
@@ -429,42 +427,6 @@ internal class BucketApiImpl(
         )
     }
 
-    private suspend fun uploadDirectAutoKey(
-        filename: String,
-        data: ByteArray,
-        contentType: String,
-        options: UploadOptions
-    ): FileUploadResponse {
-        val response = httpClient.post("$baseUrl/objects") {
-            if (options.upsert) {
-                header(BucketApi.UPSERT_HEADER, "true")
-            }
-            options.metadata?.let { metadata ->
-                header(BucketApi.METADATA_HEADER, json.encodeToString(
-                    kotlinx.serialization.serializer<Map<String, String>>(),
-                    metadata
-                ))
-            }
-            setBody(MultiPartFormDataContent(
-                formData {
-                    append("file", data, Headers.build {
-                        append(HttpHeaders.ContentType, contentType)
-                        append(HttpHeaders.ContentDisposition, "filename=\"$filename\"")
-                    })
-                }
-            ))
-        }
-
-        val storedFile = handleResponse<StoredFile>(response)
-        return FileUploadResponse(
-            bucket = storedFile.bucket,
-            key = storedFile.key,
-            size = storedFile.size,
-            mimeType = storedFile.mimeType,
-            url = storedFile.url
-        )
-    }
-
     @Suppress("UNUSED_PARAMETER")
     private suspend fun uploadPresigned(
         strategy: UploadStrategy,
@@ -508,7 +470,8 @@ internal class BucketApiImpl(
         // Extract ETag from S3 response if available
         val etag = s3Response.headers["ETag"]?.removeSurrounding("\"")
 
-        // Confirm the upload with InsForge
+        // Confirm the upload with InsForge. Confirm create-or-replaces the
+        // metadata row, matching the standard PUT semantics.
         if (strategy.confirmRequired) {
             val storedFile = confirmUpload(
                 objectKey = strategy.key,
@@ -742,3 +705,24 @@ internal class BucketApiImpl(
         )
     }
 }
+
+/**
+ * Generate a unique object key from a filename: `<sanitized-base>-<timestamp>-<random><ext>`.
+ * Auto-key generation is a client-side convenience — the storage API has no
+ * server-side key minting — so [BucketApi.uploadWithAutoKey] produces the key
+ * here and then uploads through the standard upload path.
+ */
+internal fun generateObjectKey(filename: String): String {
+    val dotIndex = filename.lastIndexOf('.')
+    val hasExt = dotIndex > 0
+    val ext = if (hasExt) filename.substring(dotIndex) else ""
+    val base = if (hasExt) filename.substring(0, dotIndex) else filename
+    val sanitizedBase = base.replace(Regex("[^a-zA-Z0-9-_]"), "-").take(32).ifEmpty { "file" }
+    val timestamp = System.currentTimeMillis()
+    val random = buildString {
+        repeat(6) { append(KEY_RANDOM_ALPHABET.random()) }
+    }
+    return "$sanitizedBase-$timestamp-$random$ext"
+}
+
+private const val KEY_RANDOM_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"

--- a/src/test/kotlin/dev/insforge/storage/StorageUploadUnitTest.kt
+++ b/src/test/kotlin/dev/insforge/storage/StorageUploadUnitTest.kt
@@ -1,0 +1,195 @@
+package dev.insforge.storage
+
+import dev.insforge.createInsforgeClient
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.*
+
+/**
+ * Unit tests for storage upload semantics (standard PUT create-or-replace)
+ * and client-side auto-key generation.
+ *
+ * All HTTP interactions go through a MockEngine — no external services needed.
+ */
+class StorageUploadUnitTest {
+
+    private val jsonContent = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private fun storedFileJson(key: String) = """
+        {
+          "bucket": "docs",
+          "key": "$key",
+          "size": 3,
+          "mimeType": "application/pdf",
+          "uploadedAt": "2026-01-01T00:00:00.000Z",
+          "url": "https://test.insforge.app/api/storage/buckets/docs/objects/$key"
+        }
+    """.trimIndent()
+
+    private fun directStrategyJson(key: String) = """
+        {
+          "method": "direct",
+          "uploadUrl": "https://test.insforge.app/api/storage/buckets/docs/objects/$key",
+          "key": "$key",
+          "confirmRequired": false
+        }
+    """.trimIndent()
+
+    // ============ generateObjectKey ============
+
+    @Test
+    fun `generateObjectKey preserves extension and appends timestamp plus random suffix`() {
+        val key = generateObjectKey("report.pdf")
+        assertTrue(
+            key.matches(Regex("""^report-\d+-[a-z0-9]{6}\.pdf$""")),
+            "Unexpected key format: $key"
+        )
+    }
+
+    @Test
+    fun `generateObjectKey sanitizes special characters in the base name`() {
+        val key = generateObjectKey("my photo (1)!.png")
+        assertTrue(
+            key.matches(Regex("""^my-photo--1---\d+-[a-z0-9]{6}\.png$""")),
+            "Unexpected key format: $key"
+        )
+    }
+
+    @Test
+    fun `generateObjectKey truncates long base names to 32 characters`() {
+        val key = generateObjectKey("a".repeat(100) + ".txt")
+        val base = key.substringBefore("-")
+        assertEquals("a".repeat(32), base)
+        assertTrue(key.endsWith(".txt"))
+    }
+
+    @Test
+    fun `generateObjectKey falls back to file base for empty filenames`() {
+        val key = generateObjectKey("")
+        assertTrue(
+            key.matches(Regex("""^file-\d+-[a-z0-9]{6}$""")),
+            "Unexpected key format: $key"
+        )
+    }
+
+    @Test
+    fun `generateObjectKey does not treat a leading dot as an extension`() {
+        val key = generateObjectKey(".gitignore")
+        assertTrue(
+            key.matches(Regex("""^-gitignore-\d+-[a-z0-9]{6}$""")),
+            "Unexpected key format: $key"
+        )
+    }
+
+    @Test
+    fun `generateObjectKey mints distinct keys for the same filename`() {
+        val keys = (1..10).map { generateObjectKey("report.pdf") }.toSet()
+        assertTrue(keys.size > 1, "Expected collision-free keys, got: $keys")
+    }
+
+    // ============ upload (standard PUT semantics) ============
+
+    @Test
+    fun `upload sends the exact key via the direct PUT route`() = runTest {
+        val requests = mutableListOf<Pair<HttpMethod, String>>()
+
+        val engine = MockEngine { request ->
+            requests.add(request.method to request.url.encodedPath)
+            val path = request.url.encodedPath
+            when {
+                path.endsWith("/upload-strategy") ->
+                    respond(directStrategyJson("report.pdf"), HttpStatusCode.OK, jsonContent)
+                request.method == HttpMethod.Put && path.contains("/objects/") ->
+                    respond(storedFileJson("report.pdf"), HttpStatusCode.OK, jsonContent)
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val client = createInsforgeClient("https://test.insforge.app", "anon-key") {
+            httpEngine = engine
+            install(Storage)
+        }
+
+        val result = client.storage["docs"].upload("report.pdf", "abc".toByteArray())
+
+        assertEquals("report.pdf", result.key)
+        val put = requests.single { it.first == HttpMethod.Put }
+        assertEquals("/api/storage/buckets/docs/objects/report.pdf", put.second)
+
+        client.close()
+    }
+
+    @Test
+    fun `uploadWithAutoKey mints a unique key client-side and uploads via the standard PUT path`() = runTest {
+        val strategyFilenames = mutableListOf<String>()
+        val putPaths = mutableListOf<String>()
+        val postObjectCalls = mutableListOf<String>()
+
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            when {
+                path.endsWith("/upload-strategy") -> {
+                    val body = Json.parseToJsonElement(String(request.body.toByteArray())).jsonObject
+                    val filename = body["filename"]!!.jsonPrimitive.content
+                    strategyFilenames.add(filename)
+                    respond(directStrategyJson(filename), HttpStatusCode.OK, jsonContent)
+                }
+                request.method == HttpMethod.Put && path.contains("/objects/") -> {
+                    putPaths.add(path)
+                    respond(storedFileJson(path.substringAfterLast("/")), HttpStatusCode.OK, jsonContent)
+                }
+                request.method == HttpMethod.Post && path.endsWith("/objects") -> {
+                    // The server-side key-minting endpoint is gone — nothing should land here.
+                    postObjectCalls.add(path)
+                    respond("", HttpStatusCode.NotFound)
+                }
+                else -> respond("", HttpStatusCode.NotFound)
+            }
+        }
+
+        val client = createInsforgeClient("https://test.insforge.app", "anon-key") {
+            httpEngine = engine
+            install(Storage)
+        }
+
+        val bucket = client.storage["docs"]
+        val result = bucket.uploadWithAutoKey("report.pdf", "abc".toByteArray())
+
+        // Client-generated key: sanitized base + timestamp + random, preserving ext.
+        val mintedKey = strategyFilenames.single()
+        assertTrue(
+            mintedKey.matches(Regex("""^report-\d+-[a-z0-9]+\.pdf$""")),
+            "Expected client-minted key, got: $mintedKey"
+        )
+        // Uploads to the client-minted key via the standard PUT route.
+        assertEquals("/api/storage/buckets/docs/objects/$mintedKey", putPaths.single())
+        assertEquals(mintedKey, result.key)
+        // The POST /objects auto-key endpoint is never used.
+        assertTrue(postObjectCalls.isEmpty(), "uploadWithAutoKey must not POST to /objects")
+
+        // Repeated uploads of the same file never overwrite each other.
+        bucket.uploadWithAutoKey("report.pdf", "abc".toByteArray())
+        assertEquals(2, strategyFilenames.toSet().size, "Keys must be collision-free: $strategyFilenames")
+
+        client.close()
+    }
+
+    @Test
+    fun `uploadWithAutoKey rejects empty data`() = runTest {
+        val engine = MockEngine { respond("", HttpStatusCode.NotFound) }
+        val client = createInsforgeClient("https://test.insforge.app", "anon-key") {
+            httpEngine = engine
+            install(Storage)
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            client.storage["docs"].uploadWithAutoKey("report.pdf", byteArrayOf())
+        }
+
+        client.close()
+    }
+}


### PR DESCRIPTION
Ports the storage changes from [InsForge-sdk-js v1.5.0](https://github.com/InsForge/InsForge-sdk-js/compare/v1.4.5...v1.5.0) (standard PUT create-or-replace semantics, paired with InsForge/InsForge#1760).

## Ported

- **`upload(path, data)` / `upload(path, file)`** — standard PUT semantics: uploading to an existing key now replaces the object in place (previously the server silently auto-renamed the key). This is a server-side behavior change; the method signatures are unchanged, KDoc updated to document the new contract.
- **`uploadWithAutoKey(filename, data)` / `uploadWithAutoKey(file)`** — the backend no longer mints keys server-side, so the unique, collision-free key is now generated client-side (`<sanitized-base>-<timestamp>-<random><ext>`, mirroring the JS `generateObjectKey` logic exactly: `[^a-zA-Z0-9-_]` → `-`, 32-char base cap, `file` fallback) and uploaded through the standard `upload()` path. The dead `POST /objects` server-minting request path (`uploadDirectAutoKey`) is removed. Public API signatures unchanged.
- **Tests** — new `StorageUploadUnitTest` (MockEngine-based, runs in the plain `test` task) mirroring the new JS unit tests: exact-key PUT routing, client-minted key format/uniqueness, no fallback to the removed `POST /objects` endpoint, empty-data rejection, plus direct coverage of `generateObjectKey` (extension preservation, sanitization, truncation, fallback, collision-freedom).

## Skipped

- JS test-harness/CI plumbing (`vitest` mocks, workflow YAML tweaks, `package.json`/lockfile version bump) — JS-only concerns.
- `SDK-REFERENCE.md` edit — the Kotlin repo has no equivalent reference doc; the contract note went into the KDoc instead.
- Version bump / changelog — this repo derives its version from git tags via axion-release and maintains no CHANGELOG file, so there is nothing to update.
- The Kotlin-specific `upsert` option is left as-is (it predates this change and remains API-compatible; with standard PUT semantics the header is now effectively a no-op server-side).

## Notes

- Like the JS release, this requires an InsForge backend that includes the standard-PUT storage change (InsForge/InsForge#1760); running against a pre-change backend will restore the old auto-rename behavior for `upload` and is unsupported.

## Test results

- `./gradlew test` (unit suite, integration-tagged tests excluded as configured): **BUILD SUCCESSFUL** — all tests pass, including the 9 new storage tests. (No JDK was on the machine; ran with a locally downloaded Temurin 17.)
- `integrationTest` requires a live InsForge backend and was not run; the existing `test upload file with auto-generated key` integration test remains valid under the new client-side key minting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs storage behavior with InsForge SDK JS v1.5.0 by adopting standard PUT create-or-replace semantics and moving auto-key generation to the client. Adds unit tests to cover the new behavior.

- **New Features**
  - `upload(path, ...)` now replaces an existing object at the same key (standard PUT).
  - `uploadWithAutoKey(...)` mints a unique key client-side (`<sanitized-base>-<timestamp>-<random><ext>`) and uploads via `upload()`. The server-side auto-key `POST /objects` path is removed.
  - KDoc updated; internal `generateObjectKey` added to mirror JS logic. New MockEngine unit tests verify exact-key PUT routing, key format/uniqueness, and empty-data rejection.

- **Migration**
  - Requires a backend with the standard-PUT storage change (InsForge/InsForge#1760). Old backends will revert to auto-rename and are unsupported.
  - Public API unchanged. The Kotlin `upsert` option remains but is effectively a no-op server-side under standard PUT.

<sup>Written for commit e2658134f7e6e02286afd32267a28521f938c511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/InsForge/insforge-kotlin/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

